### PR TITLE
React のバージョンアップ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,14 +7,15 @@
     "": {
       "name": "vval",
       "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
-        "@types/react": "^16.9.7",
+        "@types/react": "^19.1.0",
         "@types/yup": "^0.26.22",
         "del-cli": "^2.0.0",
         "typescript": "^5.1.6"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
+        "react": ">=19.1.0",
         "yup": ">=0.27.0"
       }
     },
@@ -47,20 +48,14 @@
       "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
       "dev": true
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-      "dev": true
-    },
     "node_modules/@types/react": {
-      "version": "16.9.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.9.tgz",
-      "integrity": "sha512-L+AudFJkDukk+ukInYvpoAPyJK5q1GanFOINOJnM0w6tUgITuWvJ4jyoBPFL7z4/L8hGLd+K/6xR5uUjXu0vVg==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/yup": {
@@ -154,10 +149,11 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
-      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
-      "dev": true
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/currently-unhandled": {
       "version": "0.4.1",
@@ -391,12 +387,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "peer": true
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -438,18 +428,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loud-rejection": {
@@ -701,13 +679,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     "build": "tsc"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
+    "react": ">=19.1.0",
     "yup": ">=0.27.0"
   },
   "devDependencies": {
-    "@types/react": "^16.9.7",
+    "@types/react": "^19.1.0",
     "@types/yup": "^0.26.22",
     "del-cli": "^2.0.0",
     "typescript": "^5.1.6"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ export interface VvalState<T> {
 export interface VvalProps<T> {
     initialValues: T;
     schema?: yup.ObjectSchema<{[K in keyof T]: any}>;
-    render: (params: RenderParams<T>) => JSX.Element|JSX.Element[]|string|null;
+    render: (params: RenderParams<T>) => React.ReactNode;
     immediate?: boolean;
 }
 


### PR DESCRIPTION
## 概要

- React のバージョンを 19 に更新しました
- `render()` の返り値の型を `React.ReactNode` に変更しました

## 詳細

React v15 までは、`React.Component` の `render` メソッドは返り値として `JSX.Element | null | false` を返していましたが、v16 以降では `React.ReactNode` を返すようになりました。

### 参考

- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/44ae045be8aa5fa42e6de583ab931f43d1782057/types/react/v15/index.d.ts#L325
- https://github.com/DefinitelyTyped/DefinitelyTyped/blob/44ae045be8aa5fa42e6de583ab931f43d1782057/types/react/index.d.ts#L968